### PR TITLE
Use docutils to format docstrings as LaTeX

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: no-commit-to-branch # without arguments, master/main will be protected.
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 21.6b0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
@@ -59,6 +59,7 @@ repos:
             'numpy==1.21.0',
             'spead2==3.3.2',
             'types-decorator==0.1.5',
+            'types-docutils==0.17.1',
             'types-redis==3.5.4',
             'types-setuptools==57.0.0',
             'types-six==0.1.7',

--- a/test_report/setup.cfg
+++ b/test_report/setup.cfg
@@ -12,6 +12,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
+    docutils
     matplotlib
     numpy
     pylatex

--- a/test_report/src/test_report/latex_dump.py
+++ b/test_report/src/test_report/latex_dump.py
@@ -1,7 +1,6 @@
 """Generate a PDF based on the intermediate JSON output."""
 import argparse
 import importlib.resources
-import inspect
 import json
 import os
 import tempfile
@@ -46,9 +45,9 @@ def readable_duration(duration: float) -> str:
             return f"{int(duration)} h {minutes} m {seconds:.3f} s"
 
 
-def docstring2latex(text: str) -> str:
+def rst2latex(text: str) -> str:
     """Turn a section of ReStructured Text (like a docstring) into LaTeX."""
-    return publish_parts(source=inspect.cleandoc(text), writer_name="latex")["body"]
+    return publish_parts(source=text, writer_name="latex")["body"]
 
 
 @dataclass
@@ -309,7 +308,7 @@ def document_from_json(input_data: Union[str, list]) -> Document:
     with doc.create(Section("Detailed Test Results")) as section:
         for result in results:
             with section.create(Subsection(fix_test_name(result.name), label=result.name)):
-                section.append(NoEscape(docstring2latex(result.blurb) + "\n\n"))
+                section.append(NoEscape(rst2latex(result.blurb) + "\n\n"))
                 section.append("Outcome: ")
                 section.append(TextColor("green" if result.outcome == "passed" else "red", result.outcome.upper()))
                 section.append(Command("hspace", "1cm"))


### PR DESCRIPTION
Closes NGC-609. This will probably only handle simpler cases like inline
formatting (bold etc) and lists. Any code that docutils would want to
add to the LaTeX preamble is currently discarded.

I had to update black to the latest version because the pinned version
is no longer installable thanks to breaking changes in click.
