### PR TITLE
Make assertion failures slightly prettier

### DIFF
--- a/test_report/src/test_report/latex_dump.py
+++ b/test_report/src/test_report/latex_dump.py
@@ -16,7 +16,6 @@ from dotenv import dotenv_values
 from pylatex import (
     Command,
     Document,
-    FlushLeft,
     LongTable,
     MiniPage,
     MultiColumn,
@@ -26,8 +25,18 @@ from pylatex import (
     Subsubsection,
     TextColor,
 )
+from pylatex.base_classes import Environment
 from pylatex.labelref import Hyperref
+from pylatex.package import Package
 from pylatex.utils import bold
+
+
+class LstListing(Environment):
+    """A class to wrap LaTeX's lstlisting environment."""
+
+    packages = [Package("listings")]
+    escape = False
+    content_separator = "\n"
 
 
 def readable_duration(duration: float) -> str:
@@ -345,7 +354,7 @@ def document_from_json(input_data: Union[str, list]) -> Document:
                                 procedure_table.add_hline()
 
                     if result.failure_message:
-                        with procedure.create(FlushLeft()) as failure_message:
+                        with procedure.create(LstListing()) as failure_message:
                             failure_message.append(result.failure_message)
 
     return doc

--- a/test_report/src/test_report/preamble.tex
+++ b/test_report/src/test_report/preamble.tex
@@ -5,6 +5,12 @@
 \usepackage{tablefootnote}
 \usepackage{color}
 \usepackage{colortbl}
+\usepackage{listings}
+\lstset{breaklines, breakatwhitespace, basicstyle=\scriptsize\ttfamily}
+% Magic incantation based on
+% http://www.bollchen.de/blog/2011/04/good-looking-line-breaks-with-the-listings-package/
+\lstset{prebreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\hookleftarrow}}}
+\lstset{postbreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\hookrightarrow\space}}}
 
 \newcommand{\docClient}{NRF (National Research Foundation)}
 \newcommand{\docFacility}{SARAO (South African Radio Astronomy Observatory)}


### PR DESCRIPTION
It's putting lipstick on a pig, but using the listings package instead
of flushleft plus using a small, fixed-width font means that indentation
supplied by pytest is preserved, and I've added indicators for line
wrapping.
