### PR TITLE
Remove handling of 'plot' in latex_dump.py

### DIFF
--- a/test_report/setup.cfg
+++ b/test_report/setup.cfg
@@ -13,13 +13,11 @@ package_dir =
 packages = find:
 install_requires =
     docutils
-    matplotlib
     numpy
     pylatex
     pytest
     pytest-reportlog
     python-dotenv
-    tikzplotlib
 python_requires = >=3.8
 
 [options.packages.find]


### PR DESCRIPTION
It's been superseded by 'figure'. Note that this probably breaks the
demo. I'm assuming we no longer care about the demo as this code is due
to migrate to katgpucbf anyway in (NGC-634).

See NGC-635.
