### PR TITLE
Improve centering of plots

### DIFF
--- a/test_report/src/test_report/latex_dump.py
+++ b/test_report/src/test_report/latex_dump.py
@@ -310,7 +310,8 @@ def document_from_json(input_data: Union[str, list]) -> Document:
                                         ]
                                     )
                                 elif isinstance(detail, Figure):
-                                    mp = MiniPage(width=NoEscape(r"0.6\textwidth"))
+                                    mp = MiniPage(width=NoEscape(r"\textwidth"))
+                                    mp.append(NoEscape(r"\center"))
                                     mp.append(NoEscape(detail.code))
                                     procedure_table.add_row((MultiColumn(2, align="|c|", data=mp),))
                                 procedure_table.add_hline()


### PR DESCRIPTION
Previously they were placed on the left of a minipage with width
0.6\textwidth, which was itself centered in a table. Plots were only
centered if they were 0.6\textwidth width.

Instead, give the minipage the full width (allowing for wider plots) and
explicitly center within the minipage.
